### PR TITLE
chore: bump Go and modernize golangci-lint setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,4 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: false # Use golangci-lint-action cache instead.
-      - uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.56
+      - uses: golangci/golangci-lint-action@v9

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,50 @@
+version: "2"
 run:
-  timeout: 5m
   tests: true
-  skip-dirs:
-    - .github
-  skip-files:
-    - ".*_gen.go$"
-output:
-  sort-results: true
-linters: # https://golangci-lint.run/usage/linters/
-  enable-all: true
+linters:
+  default: all
   disable:
     - depguard
-    - forbidigo
+    - err113
     - exhaustruct
+    - forbidigo
     - nlreturn
+    - noinlineerr
     - paralleltest
     - testableexamples
+    - testpackage
+    - tparallel
     - varnamelen
     - wrapcheck
-    - goerr113 # Use errorlint instead.
-    - gofmt # Use gofumpt instead.
-    - testpackage
-    - tparallel # Use paralleltest instead.
     - wsl
-    - deadcode  # deprecated
-    - exhaustivestruct # deprecated
-    - golint      # deprecated
-    - ifshort     # deprecated
-    - interfacer  # deprecated
-    - maligned    # deprecated
-    - nosnakecase # deprecated
-    - scopelint   # deprecated
-    - structcheck # deprecated
-    - varcheck    # deprecated
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - funlen
+    - wsl_v5
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - funlen
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - ^\.github/
+      - .*_gen\.go$
+formatters:
+  enable:
+    - gci
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - ^\.github/
+      - .*_gen\.go$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters:
   default: all
   disable:
     - depguard
-    - err113
+    - err113 # Use errorlint instead.
     - exhaustruct
     - forbidigo
     - nlreturn
@@ -13,11 +13,22 @@ linters:
     - paralleltest
     - testableexamples
     - testpackage
-    - tparallel
+    - tparallel # Use paralleltest instead.
     - varnamelen
     - wrapcheck
     - wsl
     - wsl_v5
+    # v1 deprecated linters (removed in v2; no longer valid disable targets):
+    # - deadcode      # deprecated
+    # - exhaustivestruct # deprecated
+    # - golint        # deprecated
+    # - ifshort       # deprecated
+    # - interfacer    # deprecated
+    # - maligned      # deprecated
+    # - nosnakecase   # deprecated
+    # - scopelint     # deprecated
+    # - structcheck   # deprecated
+    # - varcheck      # deprecated
   exclusions:
     generated: lax
     presets:
@@ -38,7 +49,7 @@ linters:
 formatters:
   enable:
     - gci
-    - gofumpt
+    - gofumpt # Use gofumpt instead.
     - goimports
   exclusions:
     generated: lax

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ichizero/errlog
 
-go 1.22
+go 1.24.0
+
+toolchain go1.26.0


### PR DESCRIPTION
## Summary
- bump go directive to 1.24.0 and toolchain to go1.26.0
- upgrade golangci-lint-action to v9 and remove pinned golangci-lint version
- migrate .golangci.yml to v2 and preserve v1 intent comments (UseInstead/deprecated notes)

## Verification
- go test ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go language target from 1.22 to 1.24.0 with added toolchain support for go1.26.0
  * Refreshed code quality tools and linting configuration to latest standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->